### PR TITLE
use.html tag extending fixed

### DIFF
--- a/elu.js
+++ b/elu.js
@@ -338,7 +338,7 @@ use.html = async function (name) {
 
 		html = (await use.text (id))
 		
-		.replace (/<([a-z]+)(.*?)\/>/gm, (m, tag, attr) => {
+		.replace (/<([a-z]+)([^<]*?)\/>/gm, (m, tag, attr) => {
 
 			switch (tag.toUpperCase ()) {
 				case 'DIV':


### PR DESCRIPTION
Правка замены тегов - неправильно работало для случаев, когда несколько тегов на одной строке, например, <div class="blank_item"><input name="dt"/></div>